### PR TITLE
Feature/#28 create war game

### DIFF
--- a/src/constants/gameResult.ts
+++ b/src/constants/gameResult.ts
@@ -1,7 +1,10 @@
 enum GameResult {
-  WIN = "win",
-  LOSE = "lose",
-  DRAW = "draw",
+  WIN = "WIN",
+  LOSE = "LOSE",
+  DRAW = "DRAW",
+  SURRENDER = "SURRENDER",
+  WAR_WIN = "WAR WIN",
+  WAR_DRAW = "WAR DRAW",
 }
 
 export default GameResult;

--- a/src/models/common/button.ts
+++ b/src/models/common/button.ts
@@ -56,6 +56,11 @@ export default class Chip extends Phaser.GameObjects.Image {
     );
   }
 
+  enable(): void {
+    this.setInteractive(true);
+    this.setVisible(true);
+  }
+
   disable(): void {
     this.setInteractive(false);
     this.setVisible(false);
@@ -64,6 +69,10 @@ export default class Chip extends Phaser.GameObjects.Image {
 
   disVisibleText(): void {
     this.text.setVisible(false);
+  }
+
+  visibleText(): void {
+    this.text.setVisible(true);
   }
 
   moveTo(toX: number, toY: number, delay: number): void {

--- a/src/models/common/card.ts
+++ b/src/models/common/card.ts
@@ -180,6 +180,23 @@ export default class Card extends Phaser.GameObjects.Image {
           King: 13,
         };
         break;
+      case "war":
+        rankToNum = {
+          Ace: 14,
+          "2": 2,
+          "3": 3,
+          "4": 4,
+          "5": 5,
+          "6": 6,
+          "7": 7,
+          "8": 8,
+          "9": 9,
+          "10": 10,
+          Jack: 11,
+          Queen: 12,
+          King: 13,
+        };
+        break;
       default:
         rankToNum = {
           Ace: 1,

--- a/src/models/common/chip.ts
+++ b/src/models/common/chip.ts
@@ -63,6 +63,11 @@ export default class Chip extends Phaser.GameObjects.Image {
     );
   }
 
+  enable(): void {
+    this.setInteractive(true);
+    this.setVisible(true);
+  }
+
   disable(): void {
     this.setInteractive(false);
     this.setVisible(false);
@@ -71,6 +76,10 @@ export default class Chip extends Phaser.GameObjects.Image {
 
   disVisibleText(): void {
     this.text.setVisible(false);
+  }
+
+  visibleText(): void {
+    this.text.setVisible(true);
   }
 
   moveTo(toX: number, toY: number, delay: number): void {

--- a/src/models/common/deck.ts
+++ b/src/models/common/deck.ts
@@ -55,4 +55,52 @@ export default class Deck {
   isEmpty(): boolean {
     return this.cards.length === 0;
   }
+
+  /**
+   * WAR DRAWのチェック用デッキ
+   * デバッグ用です
+   * 開発終わったら消すかも
+   */
+  createDrawDeck(rank: string): void {
+    this.cards = []; // Clear the current deck
+
+    // Create new deck with all cards of the specified rank
+    SUITS.forEach((suit) => {
+      const textureKey = `${suit}${rank}`;
+      this.cards.push(new Card(this.scene, this.x, this.y, rank, suit, textureKey, true));
+    });
+  }
+
+  /**
+   * WAR WINのチェック用デッキ
+   * デバッグ用です
+   * 開発終わったら消すかも
+   */
+  createPlayerWarWinDeck(): void {
+    this.cards = []; // Clear the current deck
+
+    // Dealer's war loss card
+    const dealerWarLossCardTextureKey = `clubs2`;
+    this.cards.push(
+      new Card(this.scene, this.x, this.y, "2", "clubs", dealerWarLossCardTextureKey, true)
+    );
+
+    // Player's war win card
+    const playerWarWinCardTextureKey = `heartsKing`;
+    this.cards.push(
+      new Card(this.scene, this.x, this.y, "King", "hearts", playerWarWinCardTextureKey, true)
+    );
+
+    // Player's draw card
+    const playerDrawCardTextureKey = `diamondsQueen`;
+    this.cards.push(
+      new Card(this.scene, this.x, this.y, "Queen", "diamonds", playerDrawCardTextureKey, true)
+    );
+
+    // Dealer's draw card
+    const dealerDrawCardTextureKey = `spadesQueen`;
+    this.cards.push(
+      new Card(this.scene, this.x, this.y, "Queen", "spades", dealerDrawCardTextureKey, true)
+    );
+  }
 }

--- a/src/models/common/player.ts
+++ b/src/models/common/player.ts
@@ -82,5 +82,12 @@ export default abstract class Player {
     }
   }
 
+  /**
+   * 手札のリセット
+   */
+  resetHand(): void {
+    this.hand = [];
+  }
+
   abstract calculateHandScore(): number;
 }

--- a/src/models/games/war/warPlayer.ts
+++ b/src/models/games/war/warPlayer.ts
@@ -1,4 +1,3 @@
-import Card from "../../common/card";
 import Player from "../../common/player";
 
 export default class WarPlayer extends Player {

--- a/src/models/games/war/warPlayer.ts
+++ b/src/models/games/war/warPlayer.ts
@@ -1,0 +1,9 @@
+import Card from "../../common/card";
+import Player from "../../common/player";
+
+export default class WarPlayer extends Player {
+  calculateHandScore(): number {
+    if (!this.getHand || this.getHand.length === 0) return 0;
+    return this.getHand[0].getRankNumber("war");
+  }
+}

--- a/src/scenes/common/TableScene.ts
+++ b/src/scenes/common/TableScene.ts
@@ -37,6 +37,8 @@ export default abstract class TableScene extends Phaser.Scene {
 
   protected betText: Text | undefined;
 
+  protected resultText: Text | undefined;
+
   protected initialTime = 2;
 
   protected chipButtons: Array<Chip> = [];
@@ -149,10 +151,11 @@ export default abstract class TableScene extends Phaser.Scene {
     };
 
     // テキストオブジェクトを作成
-    const resultText = this.add.text(0, 0, resultMessage, resultStyle);
+    this.resultText = this.add.text(0, 0, resultMessage, resultStyle);
+    this.resultText.name = "resultText";
 
     Phaser.Display.Align.In.Center(
-      resultText,
+      this.resultText,
       this.add.zone(
         this.cameras.main.width / 2,
         this.cameras.main.height / 2,
@@ -214,7 +217,7 @@ export default abstract class TableScene extends Phaser.Scene {
   /**
    * Dealボタン作成
    */
-  protected createDealButton() {
+  protected createDealButton(): void {
     this.dealButton = new Button(
       this,
       this.scale.width / 2 + 150,
@@ -245,7 +248,7 @@ export default abstract class TableScene extends Phaser.Scene {
   /**
    * クリアボタンを表示
    */
-  protected createClearButton() {
+  protected createClearButton(): void {
     this.clearButton = new Button(
       this,
       this.scale.width / 2 - 150,
@@ -304,6 +307,31 @@ export default abstract class TableScene extends Phaser.Scene {
   }
 
   /**
+   * betフェーズに使うUIを表示する
+   */
+  protected enableBetItem() {
+    this.chipButtons.forEach((chip) => {
+      chip.enable();
+    });
+
+    // テキストは時間差で表示する
+    this.time.delayedCall(200, () => {
+      this.chipButtons.forEach((chip) => {
+        chip.visibleText();
+      });
+    });
+
+    this.dealButton.enable();
+    this.clearButton.enable();
+
+    // テキストは時間差で表示する
+    this.time.delayedCall(200, () => {
+      this.dealButton.visibleText();
+      this.clearButton.visibleText();
+    });
+  }
+
+  /**
    * betフェーズのみ使うUIを非表示にする
    */
   protected disableBetItem(): void {
@@ -311,5 +339,19 @@ export default abstract class TableScene extends Phaser.Scene {
       chip.disable();
     });
     this.dealButton.disable();
+    this.clearButton.disable();
+  }
+
+  /**
+   * betフェーズに使うUIをフェードインさせる
+   */
+  protected fadeInBetItem(): void {
+    // UIをフェードインさせる
+    this.chipButtons.forEach((chip) => {
+      chip.moveTo(chip.x, chip.y + 700, 200);
+    });
+
+    this.dealButton.moveTo(this.dealButton.x, this.dealButton.y - 700, 200);
+    this.clearButton.moveTo(this.clearButton.x, this.clearButton.y - 700, 200);
   }
 }

--- a/src/scenes/common/TableScene.ts
+++ b/src/scenes/common/TableScene.ts
@@ -129,6 +129,15 @@ export default abstract class TableScene extends Phaser.Scene {
       case GameResult.DRAW:
         resultMessage = "DRAW";
         break;
+      case GameResult.WAR_WIN:
+        resultMessage = "YOU WIN!!";
+        break;
+      case GameResult.WAR_DRAW:
+        resultMessage = "WAR DRAW";
+        break;
+      case GameResult.SURRENDER:
+        resultMessage = "SURRENDER";
+        break;
       default:
         resultMessage = "GAME OVER";
     }

--- a/src/scenes/common/TableScene.ts
+++ b/src/scenes/common/TableScene.ts
@@ -228,8 +228,8 @@ export default abstract class TableScene extends Phaser.Scene {
     this.dealButton.setClickHandler(() => {
       if (this.bet > 0) {
         const player = this.players[0];
-        player.setChips = player.getChips - this.bet;
-        this.setCreditText();
+        const displayCredit = player.getChips - this.bet;
+        this.setCreditText(displayCredit);
 
         // UIをフェードアウトさせる
         this.chipButtons.forEach((chip) => {
@@ -338,8 +338,8 @@ export default abstract class TableScene extends Phaser.Scene {
   /**
    * 現在の所持金を画面にセット
    */
-  protected setCreditText(): void {
-    this.creditText?.setText(`CREDIT: $${this.players[0].getChips}`);
+  protected setCreditText(displayCredit): void {
+    this.creditText?.setText(`CREDIT: $${displayCredit}`);
   }
 
   /**

--- a/src/scenes/games/war/warTableScene.ts
+++ b/src/scenes/games/war/warTableScene.ts
@@ -227,14 +227,15 @@ export default class WarTableScene extends TableScene {
         player.addCardToHand(newCard);
         if (player.getPlayerType === PlayerType.PLAYER) {
           newCard.moveTo(centerWidth, centerHeight + 170, 200);
+          newCard.setTexture("cards", newCard.getTextureKey);
         } else if (player.getPlayerType === PlayerType.DEALER) {
           newCard.moveTo(centerWidth, centerHeight - 170, 200);
+          // カードを裏返す
+          this.time.delayedCall(1500, () => {
+            newCard.flipToFront();
+          });
         }
         this.children.bringToTop(newCard);
-        // カードを裏返す
-        this.time.delayedCall(1500, () => {
-          newCard.flipToFront();
-        });
       }
     });
   }

--- a/src/scenes/games/war/warTableScene.ts
+++ b/src/scenes/games/war/warTableScene.ts
@@ -1,1 +1,130 @@
-(game as HTMLDivElement).innerHTML = "War!!!";
+import TableScene from "../../common/TableScene";
+import Deck from "../../../models/common/deck";
+import Card from "../../../models/common/card";
+import WarPlayer from "../../../models/games/war/warPlayer";
+import GameState from "../../../constants/gameState";
+import GameResult from "../../../constants/gameResult";
+import PlayerType from "../../../constants/playerType";
+import Zone = Phaser.GameObjects.Zone;
+import GameObject = Phaser.GameObjects.GameObject;
+import TimeEvent = Phaser.Time.TimerEvent;
+
+const D_WIDTH = 1320;
+const D_HEIGHT = 920;
+
+export default class WarTableScene extends TableScene {
+  private result: string | undefined; // WIN or LOSE or DRAW
+
+  private gameStarted = false;
+
+  constructor() {
+    super({});
+
+    this.players = [
+      new WarPlayer("Player", PlayerType.PLAYER, 1000, 0),
+      new WarPlayer("Cpu", PlayerType.CPU, 0, 0),
+    ];
+  }
+
+  preload(): void {
+    this.load.atlas("cards", "/public/assets/images/cards.png", "/public/assets/images/cards.json");
+    this.load.image("table", "/public/assets/images/tableGreen.png");
+    this.load.image("chipWhite", "/public/assets/images/chipWhite.png");
+    this.load.image("chipYellow", "/public/assets/images/chipYellow.png");
+    this.load.image("chipBlue", "/public/assets/images/chipBlue.png");
+    this.load.image("chipOrange", "/public/assets/images/chipOrange.png");
+    this.load.image("chipRed", "/public/assets/images/chipRed.png");
+    this.load.image("buttonRed", "/public/assets/images/buttonRed.png");
+  }
+
+  create(): void {
+    this.add.image(D_WIDTH / 2, D_HEIGHT / 2, "table");
+    this.gameState = GameState.BETTING;
+    this.createGameZone();
+    this.createChips();
+    this.createDealButton();
+    this.createClearButton();
+    this.createCreditField();
+  }
+
+  update(): void {
+    if (this.gameState === GameState.PLAYING && !this.gameStarted) {
+      this.disableBetItem();
+      this.startGame();
+      this.gameStarted = true;
+    }
+
+    this.checkResult();
+
+    if (this.gameState === GameState.END_GAME) {
+      // ゲームresult画面
+      if (this.result) {
+        this.displayResult(this.result, 0);
+
+        // TODO result画面のBGM設定
+        // TODO chipやスコアの更新
+      }
+    }
+  }
+
+  private startGame(): void {
+    this.dealCards();
+  }
+
+  /**
+   * カードの初期配置処理
+   */
+  dealCards(): void {
+    console.log("カードの初期配置を開始します");
+    this.deck = new Deck(this, this.scale.width / 2, this.scale.height / 2, [
+      "hearts",
+      "diamonds",
+      "spades",
+      "clubs",
+    ]);
+
+    // let dropZonesIndex = 0;
+    // this.players.forEach((player, index) => {
+    //   this.dealHandCards(player as SpeedPlayer, index);
+    //   this.dealLeadCards(player as SpeedPlayer, index, this.dropZones[dropZonesIndex]);
+    //   dropZonesIndex += 1;
+    // });
+  }
+
+  /**
+   * 勝敗判定
+   */
+  private checkResult(): void {
+    if (this.gameState !== GameState.PLAYING) return;
+    const playerScore = this.players[0].calculateHandScore();
+    const cpuScore = this.players[1].calculateHandScore();
+  }
+}
+
+const config: Phaser.Types.Core.GameConfig = {
+  type: Phaser.AUTO,
+  width: D_WIDTH,
+  height: D_HEIGHT,
+  antialias: false,
+  scene: WarTableScene,
+  mode: Phaser.Scale.FIT,
+  parent: "game-content",
+  autoCenter: Phaser.Scale.CENTER_BOTH,
+  min: {
+    width: 720,
+    height: 345,
+  },
+  max: {
+    width: 1920,
+    height: 920,
+  },
+  fps: {
+    target: 60,
+    forceSetTimeOut: true,
+  },
+  physics: {
+    default: "arcade",
+  },
+};
+
+const phaser = new Phaser.Game(config);


### PR DESCRIPTION
## 関連するIssueやプルリクエスト
#28 

## 変更の概要
- war基本機能
- 勝敗後の導線作成

## 変更内容
- 基本機能の実装
- 勝敗判定後の配当ロジックの追加
- ベット→プレイ→勝敗判定→ベットの
- リザルト画面の表示内容を拡張

## どうやるのか

https://github.com/Recursion-Group-B/card-game/assets/69625901/3718bc3c-5474-4057-b84e-21347c846fac

引き分け時の処理


勝敗 | 配当
-- | --
勝ち | 最初の賭け金は返却、追加分はその2倍の配当
負け | 最初と追加の賭け金は両方没収
引き分け | 最初と追加の賭け金それぞれ2倍の配当



## 課題
正しい配当が反映されてるか？

特に↑の配当周りの処理を重点的に見て頂きたいです
