### PR TITLE
Feature/#54 difficulty setting

### DIFF
--- a/src/constants/gameType.ts
+++ b/src/constants/gameType.ts
@@ -1,0 +1,8 @@
+enum GameType {
+  BLACKJACK = "blackjack",
+  POKER = "poker",
+  SPEED = "speed",
+  WAR = "war",
+}
+
+export default GameType;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import "./style.scss";
 import Home from "./pages/home";
 import setAnimation from "./pages/components/setAnimation";
 import setScreen from "./pages/components/setScreen";
+import insertCanvas from "./pages/components/insertCanvas";
 
 // html挿入
 (document.querySelector("#app") as HTMLDivElement).innerHTML = `
@@ -19,3 +20,8 @@ setAnimation();
  * [画面遷移]
  */
 setScreen();
+
+/**
+ * canvasを埋め込む
+ */
+insertCanvas();

--- a/src/models/common/game.ts
+++ b/src/models/common/game.ts
@@ -1,0 +1,8 @@
+const GAME = {
+  CONFIG: {
+    DIFFICULTY: "Easy",
+    GAME_MODE: "",
+  },
+};
+
+export default GAME;

--- a/src/models/common/gameManager.ts
+++ b/src/models/common/gameManager.ts
@@ -1,0 +1,24 @@
+import GameType from "../../constants/gameType";
+import Game from "./game";
+
+export default class GameManager {
+  static setGameType(gameName: GameType) {
+    switch (gameName) {
+      case GameType.BLACKJACK:
+        Game.CONFIG.GAME_MODE = GameType.BLACKJACK;
+        break;
+      case GameType.POKER:
+        Game.CONFIG.GAME_MODE = GameType.POKER;
+        break;
+      case GameType.SPEED:
+        Game.CONFIG.GAME_MODE = GameType.SPEED;
+        break;
+      case GameType.WAR:
+        Game.CONFIG.GAME_MODE = GameType.WAR;
+        break;
+      default:
+        // ゲームは適宜追加
+        break;
+    }
+  }
+}

--- a/src/pages/components/initGame.ts
+++ b/src/pages/components/initGame.ts
@@ -1,0 +1,53 @@
+import Phaser from "phaser";
+
+export default async function initGame(gameType: string) {
+  let gameScene;
+
+  switch (gameType) {
+    case "speed":
+      gameScene = (await import("../../scenes/games/speed/speedTableScene")).default;
+      break;
+    case "poker":
+      gameScene = (await import("../../scenes/games/poker/pokerTableScene")).default;
+      break;
+    case "blackjack":
+      gameScene = (await import("../../scenes/games/poker/pokerTableScene")).default;
+      break;
+    case "war":
+      gameScene = (await import("../../scenes/games/poker/pokerTableScene")).default;
+      break;
+    default:
+      throw new Error("Invalid game type");
+  }
+
+  const D_WIDTH = 1320;
+  const D_HEIGHT = 920;
+
+  const config: Phaser.Types.Core.GameConfig = {
+    type: Phaser.AUTO,
+    width: D_WIDTH,
+    height: D_HEIGHT,
+    antialias: false,
+    scene: gameScene,
+    mode: Phaser.Scale.FIT,
+    parent: "game-content",
+    autoCenter: Phaser.Scale.CENTER_BOTH,
+    min: {
+      width: 720,
+      height: 345,
+    },
+    max: {
+      width: 1920,
+      height: 920,
+    },
+    fps: {
+      target: 60,
+      forceSetTimeOut: true,
+    },
+    physics: {
+      default: "arcade",
+    },
+  };
+
+  const phaser = new Phaser.Game(config);
+}

--- a/src/pages/components/initGame.ts
+++ b/src/pages/components/initGame.ts
@@ -1,4 +1,22 @@
 import Phaser from "phaser";
+import GameManager from "../../models/common/gameManager";
+import GameType from "../../constants/gameType";
+
+/**
+ * home画面非表示
+ */
+function hideHome() {
+  const homeElement = document.getElementById("home");
+  const headerElement = document.getElementById("header");
+
+  if (homeElement) {
+    homeElement.classList.add("d-none");
+  }
+
+  if (headerElement) {
+    headerElement.classList.add("d-none");
+  }
+}
 
 export default async function initGame(gameType: string) {
   let gameScene;
@@ -19,6 +37,12 @@ export default async function initGame(gameType: string) {
     default:
       throw new Error("Invalid game type");
   }
+
+  // Homeを非表示
+  hideHome();
+
+  // ゲームの設定
+  GameManager.setGameType(gameType as GameType);
 
   const D_WIDTH = 1320;
   const D_HEIGHT = 920;

--- a/src/pages/components/initGame.ts
+++ b/src/pages/components/initGame.ts
@@ -29,10 +29,10 @@ export default async function initGame(gameType: string) {
       gameScene = (await import("../../scenes/games/poker/pokerTableScene")).default;
       break;
     case "blackjack":
-      gameScene = (await import("../../scenes/games/poker/pokerTableScene")).default;
+      gameScene = (await import("../../scenes/games/blackjack/blackjackTableScene")).default;
       break;
     case "war":
-      gameScene = (await import("../../scenes/games/poker/pokerTableScene")).default;
+      gameScene = (await import("../../scenes/games/war/warTableScene")).default;
       break;
     default:
       throw new Error("Invalid game type");

--- a/src/pages/components/insertCanvas.ts
+++ b/src/pages/components/insertCanvas.ts
@@ -1,6 +1,6 @@
 import initGame from "./initGame";
 
-export default function gameSelector() {
+export default function insertCanvas() {
   document.querySelectorAll(".btn[data-game]").forEach((button) => {
     button.addEventListener("click", async (event) => {
       const gameType = (event.currentTarget as Element).getAttribute("data-game");

--- a/src/pages/components/insertCanvas.ts
+++ b/src/pages/components/insertCanvas.ts
@@ -1,0 +1,12 @@
+import initGame from "./initGame";
+
+export default function gameSelector() {
+  document.querySelectorAll(".btn[data-game]").forEach((button) => {
+    button.addEventListener("click", async (event) => {
+      const gameType = (event.currentTarget as Element).getAttribute("data-game");
+      if (gameType) {
+        await initGame(gameType);
+      }
+    });
+  });
+}

--- a/src/pages/components/selectGame.ts
+++ b/src/pages/components/selectGame.ts
@@ -3,27 +3,27 @@ const selectGame = `
     <div id="imgList" class="d-none">
         <div id="poker" class="slider-item">
             <h3>Poker</h3>
-            <a href="src/pages/poker.html">
+            <button class="btn btn-link text-reset" data-game="poker">
                 <img src="public/pokerImg.png" class="img-fit">
-            </a>
+            </button>
         </div>
         <div id="blackjack" class="slider-item">
             <h3>BlackJack</h3>
-            <a href="src/pages/blackjack.html">
+            <button class="btn btn-link text-reset" data-game="blackjack">
                 <img src="public/blackjackImg.png" class="img-fit">
-            </a>
+            </button>
         </div>
         <div id="war" class="slider-item">
             <h3>War</h3>
-            <a href="src/pages/war.html">
+            <button class="btn btn-link text-reset" data-game="war">
                 <img src="public/warImg.png" class="img-fit">
-            </a>
+            </button>
         </div>
         <div id="speed" class="slider-item">
             <h3>Speed</h3>
-            <a href="src/pages/speed.html">
+            <button class="btn btn-link text-reset" data-game="speed">
                 <img src="public/speedImg.png" class="img-fit">
-            </a>
+            </button>
         </div>
     </div>
     <div class="slides d-flex justify-content-around">

--- a/src/pages/home.ts
+++ b/src/pages/home.ts
@@ -24,6 +24,8 @@ const Home = `
     <div id="myPage" class="d-none page">
         ${myPage}
     </div>
+    <div id="game-content">
+    </div>
 `;
 
 export default Home;

--- a/src/scenes/games/blackjack/blackjackTableScene.ts
+++ b/src/scenes/games/blackjack/blackjackTableScene.ts
@@ -12,7 +12,6 @@ import TimeEvent = Phaser.Time.TimerEvent;
 const D_WIDTH = 1320;
 const D_HEIGHT = 920;
 
-
 export default class BlackJackTableScene extends TableScene {
   private playerPositionX = 500;
   private playerPositionY = 600;
@@ -82,10 +81,9 @@ export default class BlackJackTableScene extends TableScene {
     }
   }
 
-
   /**
-  * 山札作成
-  */
+   * 山札作成
+   */
   makeDeck() {
     this.deck = new Deck(this, 1050, 450);
     this.deck.shuffle();
@@ -114,7 +112,7 @@ export default class BlackJackTableScene extends TableScene {
           card.setInteractive();
           // ここから追加した
           this.addPlayerPositionX += 85;
-          this.playerTotalhand += card.getRankNumber("blackjack")
+          this.playerTotalhand += card.getRankNumber("blackjack");
         } else if (player.getPlayerType === "cpu") {
           // ブラックジャックはCPUの一枚目を表面にする
           if (index === 0) {
@@ -125,7 +123,7 @@ export default class BlackJackTableScene extends TableScene {
             card.moveTo(this.cpuPositionX + this.addCpuPositionX, this.cpuPositionY, 500);
           }
           this.addCpuPositionX = this.addCpuPositionX + 85;
-          this.cpuTotalhand += card.getRankNumber("blackjack")
+          this.cpuTotalhand += card.getRankNumber("blackjack");
         }
       });
     });
@@ -136,14 +134,14 @@ export default class BlackJackTableScene extends TableScene {
    */
   playerDisplayTotal(): void {
     // プレイヤー
-     const playerTotal = this.add
-     .text(this.playerPositionX + 120, this.playerPositionY - 95, `${this.playerTotalhand}`, {
-       fontFamily: "Arial Black",
-       fontSize: 30,
-     })
-     .setName("roleName");
+    const playerTotal = this.add
+      .text(this.playerPositionX + 120, this.playerPositionY - 95, `${this.playerTotalhand}`, {
+        fontFamily: "Arial Black",
+        fontSize: 30,
+      })
+      .setName("roleName");
 
-     this.playerScoreTexts.push(playerTotal);
+    this.playerScoreTexts.push(playerTotal);
   }
 
   /**
@@ -151,9 +149,7 @@ export default class BlackJackTableScene extends TableScene {
    */
   setPlayerDisplayTotal(): void {
     const playerScoreText = this.playerScoreTexts[0];
-      playerScoreText.setText(
-      this.playerTotalhand.toString()
-    );
+    playerScoreText.setText(this.playerTotalhand.toString());
   }
 
   /**
@@ -162,11 +158,11 @@ export default class BlackJackTableScene extends TableScene {
   cpuDisplayTotal(): void {
     // CPU
     const cpuTotal = this.add
-    .text(this.cpuPositionX + 120, this.cpuPositionY + 65, `${this.cpuTotalhand}`, {
-      fontFamily: "Arial Black",
-      fontSize: 30,
-    })
-    .setName("roleName");
+      .text(this.cpuPositionX + 120, this.cpuPositionY + 65, `${this.cpuTotalhand}`, {
+        fontFamily: "Arial Black",
+        fontSize: 30,
+      })
+      .setName("roleName");
 
     this.cpuScoreTexts.push(cpuTotal);
   }
@@ -177,11 +173,8 @@ export default class BlackJackTableScene extends TableScene {
    */
   setCpuDisplayTotal(): void {
     const cpuScoreText = this.cpuScoreTexts[0];
-      cpuScoreText.setText(
-      this.playerTotalhand.toString()
-    );
+    cpuScoreText.setText(this.playerTotalhand.toString());
   }
-
 
   /**
    * プレイヤーアクション（stand）を描画
@@ -194,62 +187,58 @@ export default class BlackJackTableScene extends TableScene {
       .setOrigin(0.5)
       .setInteractive();
 
+    stand.on(
+      "pointerdown",
+      function standJudge(this: BlackJackTableScene) {
+        // ① CPUの手札を全てオープン、Totalを表示
+        this.players[1].getHand?.forEach((card) => {
+          card.flipToFront(); // 表に表示する速度を変更したい
+        });
 
-      stand.on(
-        "pointerdown",
-        function standJudge(this: BlackJackTableScene) {
-          // ① CPUの手札を全てオープン、Totalを表示
-           this.players[1].getHand?.forEach((card) => {
-            card.flipToFront(); // 表に表示する速度を変更したい
+        // ② 17以上になるまでHitを行う
+        while (this.cpuTotalhand < 17) {
+          this.players[1].setHand = (this.deck as Deck).draw(1) as Card[];
+          this.players[1].getHand?.forEach((card) => {
+            card.moveTo(this.cpuPositionX + this.addCpuPositionX, this.cpuPositionY, 500);
+            setTimeout(() => card.flipToFront(), 800);
+            card.setInteractive();
+            // ここから追加 ※ あとで共通化する
+            this.addCpuPositionX += 85;
+            this.cpuTotalhand += card.getRankNumber("blackjack");
           });
+        }
+        // ③ CPUとPlayerで勝敗を比較する
+        // ④ Player視点で勝ち負けの表示を行う
+        this.cpuDisplayTotal(); // 最後のトータルだけ表示 ※ 課題 : CPUのトータルをDrawごとにカウントしたい
 
-          // ② 17以上になるまでHitを行う
-          while(this.cpuTotalhand < 17) {
-            this.players[1].setHand = (this.deck as Deck).draw(1) as Card[];
-            this.players[1].getHand?.forEach((card) => {
-              card.moveTo(this.cpuPositionX + this.addCpuPositionX, this.cpuPositionY, 500);
-              setTimeout(() => card.flipToFront(), 800);
-              card.setInteractive();
-                // ここから追加 ※ あとで共通化する
-                this.addCpuPositionX += 85;
-                this.cpuTotalhand += card.getRankNumber("blackjack")
-            });
-          }
-          // ③ CPUとPlayerで勝敗を比較する
-          // ④ Player視点で勝ち負けの表示を行う
-          this.cpuDisplayTotal(); // 最後のトータルだけ表示 ※ 課題 : CPUのトータルをDrawごとにカウントしたい
-
-          if(this.playerTotalhand > this.cpuTotalhand || this.cpuTotalhand > 21) {
-            // 勝利の表示
-            this.add
+        if (this.playerTotalhand > this.cpuTotalhand || this.cpuTotalhand > 21) {
+          // 勝利の表示
+          this.add
             .text(this.playerPositionX, this.playerPositionY - 180, `WIN`, {
               fontFamily: "Arial Black",
               fontSize: 50,
             })
             .setName("roleName");
-          }
-          else if(this.playerTotalhand == this.cpuTotalhand) {
-            // 引き分けの表示
-            this.add
+        } else if (this.playerTotalhand == this.cpuTotalhand) {
+          // 引き分けの表示
+          this.add
             .text(this.playerPositionX, this.playerPositionY - 180, `DRAW`, {
               fontFamily: "Arial Black",
               fontSize: 50,
             })
             .setName("roleName");
-          }
-          else {
-            // 負けの表示
-            this.add
+        } else {
+          // 負けの表示
+          this.add
             .text(this.playerPositionX, this.playerPositionY - 180, `LOSS`, {
               fontFamily: "Arial Black",
               fontSize: 50,
             })
             .setName("roleName");
-          }
-        },
-        this
-      );
-
+        }
+      },
+      this
+    );
   }
 
   /**
@@ -263,49 +252,53 @@ export default class BlackJackTableScene extends TableScene {
       .setOrigin(0.5)
       .setInteractive();
 
-      // イベント 一枚引く
-      hit.on(
-        "pointerdown",
-        function drawCard(this: BlackJackTableScene, pointer: Phaser.Input.Pointer) {
-          this.players.forEach((player) => {
-            // playerだけに絞りたい
-            if (player.getPlayerType === "player") {
-              player.setHand = (this.deck as Deck).draw(1) as Card[];
-              // カードを配る配置を変えたい
-              player.getHand?.forEach((card) => {
-                  card.moveTo(this.playerPositionX + this.addPlayerPositionX, this.playerPositionY, 500);
-                  setTimeout(() => card.flipToFront(), 800);
-                  card.setInteractive();
-                  // ここから追加 ※ 後ほど共通化する
-                  this.addPlayerPositionX += 85;
-                  this.playerTotalhand += card.getRankNumber("blackjack")
+    // イベント 一枚引く
+    hit.on(
+      "pointerdown",
+      function drawCard(this: BlackJackTableScene, pointer: Phaser.Input.Pointer) {
+        this.players.forEach((player) => {
+          // playerだけに絞りたい
+          if (player.getPlayerType === "player") {
+            player.setHand = (this.deck as Deck).draw(1) as Card[];
+            // カードを配る配置を変えたい
+            player.getHand?.forEach((card) => {
+              card.moveTo(
+                this.playerPositionX + this.addPlayerPositionX,
+                this.playerPositionY,
+                500
+              );
+              setTimeout(() => card.flipToFront(), 800);
+              card.setInteractive();
+              // ここから追加 ※ 後ほど共通化する
+              this.addPlayerPositionX += 85;
+              this.playerTotalhand += card.getRankNumber("blackjack");
 
-                  // 一枚引いてカードの表示を変える
-                  this.setPlayerDisplayTotal();
-              });
-            }
-          });
-
-          // 21を超えたらBust
-          if(this.playerTotalhand > 21) {
-            // BUSTを表示 ※ 21を超えたら強制的に負け
-            this.add
-              .text(this.playerPositionX, this.playerPositionY - 180, `BUST`, {
-                fontFamily: "Arial Black",
-                fontSize: 50,
-              })
-              .setName("roleName");
-            // CPUの手札も表に表示する
-            this.players[1].getHand?.forEach((card) => {
-              card.flipToFront(); // 表に表示する速度を変更したい
+              // 一枚引いてカードの表示を変える
+              this.setPlayerDisplayTotal();
             });
-            // 新規追加
-            this.cpuDisplayTotal();
-            // 課題 : ベットをする画面に遷移させる
           }
-        },
-        this
-      );
+        });
+
+        // 21を超えたらBust
+        if (this.playerTotalhand > 21) {
+          // BUSTを表示 ※ 21を超えたら強制的に負け
+          this.add
+            .text(this.playerPositionX, this.playerPositionY - 180, `BUST`, {
+              fontFamily: "Arial Black",
+              fontSize: 50,
+            })
+            .setName("roleName");
+          // CPUの手札も表に表示する
+          this.players[1].getHand?.forEach((card) => {
+            card.flipToFront(); // 表に表示する速度を変更したい
+          });
+          // 新規追加
+          this.cpuDisplayTotal();
+          // 課題 : ベットをする画面に遷移させる
+        }
+      },
+      this
+    );
   }
 
   /**
@@ -333,17 +326,16 @@ export default class BlackJackTableScene extends TableScene {
       .setOrigin(0.5)
       .setInteractive();
 
-
     surrender.on(
       "pointerdown",
       function displaySurrender(this: BlackJackTableScene) {
         // 「Surrender」を表示
         this.add
-        .text(this.playerPositionX, this.playerPositionY - 180, `Surrender`, {
-          fontFamily: "Arial Black",
-          fontSize: 50,
-        })
-        .setName("roleName");
+          .text(this.playerPositionX, this.playerPositionY - 180, `Surrender`, {
+            fontFamily: "Arial Black",
+            fontSize: 50,
+          })
+          .setName("roleName");
 
         // 課題 : ベット機能追加後 ※ベット金額 / 2が引かれる
       },
@@ -351,32 +343,3 @@ export default class BlackJackTableScene extends TableScene {
     );
   }
 }
-
-
-const config: Phaser.Types.Core.GameConfig = {
-    type: Phaser.AUTO,
-    width: D_WIDTH,
-    height: D_HEIGHT,
-    antialias: false,
-    scene: BlackJackTableScene,
-    mode: Phaser.Scale.FIT,
-    parent: "game-content",
-    autoCenter: Phaser.Scale.CENTER_BOTH,
-    min: {
-      width: 720,
-      height: 345,
-    },
-    max: {
-      width: 1920,
-      height: 920,
-    },
-    fps: {
-      target: 60,
-      forceSetTimeOut: true,
-    },
-    physics: {
-      default: "arcade",
-    },
-  };
-
-  const phaser = new Phaser.Game(config);

--- a/src/scenes/games/poker/pokerTableScene.ts
+++ b/src/scenes/games/poker/pokerTableScene.ts
@@ -35,10 +35,6 @@ export default class PokerTableScene extends TableScene {
     this.players = [new PokerPlayer("Player", "player", 0, 0), new PokerPlayer("Cpu", "cpu", 0, 0)];
     this.pot = [0];
     this.returnPot = 0;
-
-    console.log("aaaaaaaaaaaaaaaa");
-    console.log(Game.CONFIG.DIFFICULTY);
-    console.log(Game.CONFIG.GAME_MODE);
   }
 
   addCPU(player: PokerPlayer): void {

--- a/src/scenes/games/poker/pokerTableScene.ts
+++ b/src/scenes/games/poker/pokerTableScene.ts
@@ -290,31 +290,3 @@ export default class PokerTableScene extends TableScene {
     );
   }
 }
-
-const config: Phaser.Types.Core.GameConfig = {
-  type: Phaser.AUTO,
-  width: D_WIDTH,
-  height: D_HEIGHT,
-  antialias: false,
-  scene: PokerTableScene,
-  mode: Phaser.Scale.FIT,
-  parent: "game-content",
-  autoCenter: Phaser.Scale.CENTER_BOTH,
-  min: {
-    width: 720,
-    height: 345,
-  },
-  max: {
-    width: 1920,
-    height: 920,
-  },
-  fps: {
-    target: 60,
-    forceSetTimeOut: true,
-  },
-  physics: {
-    default: "arcade",
-  },
-};
-
-const phaser = new Phaser.Game(config);

--- a/src/scenes/games/poker/pokerTableScene.ts
+++ b/src/scenes/games/poker/pokerTableScene.ts
@@ -5,6 +5,7 @@ import Card from "../../../models/common/card";
 import PokerPlayer from "../../../models/games/poker/pokerPlayer";
 import TableScene from "../../common/TableScene";
 import { HandScore } from "../../../models/games/poker/type";
+import Game from "../../../models/common/game";
 
 const D_WIDTH = 1320;
 const D_HEIGHT = 920;
@@ -34,6 +35,10 @@ export default class PokerTableScene extends TableScene {
     this.players = [new PokerPlayer("Player", "player", 0, 0), new PokerPlayer("Cpu", "cpu", 0, 0)];
     this.pot = [0];
     this.returnPot = 0;
+
+    console.log("aaaaaaaaaaaaaaaa");
+    console.log(Game.CONFIG.DIFFICULTY);
+    console.log(Game.CONFIG.GAME_MODE);
   }
 
   addCPU(player: PokerPlayer): void {

--- a/src/scenes/games/speed/speedTableScene.ts
+++ b/src/scenes/games/speed/speedTableScene.ts
@@ -1,6 +1,7 @@
 import TableScene from "../../common/TableScene";
 import Deck from "../../../models/common/deck";
 import Card from "../../../models/common/card";
+import Game from "../../../models/common/game";
 import SpeedPlayer from "../../../models/games/speed/speedPlayer";
 import GameState from "../../../constants/gameState";
 import GameResult from "../../../constants/gameResult";
@@ -52,6 +53,10 @@ export default class SpeedTableScene extends TableScene {
   create(): void {
     this.add.image(D_WIDTH / 2, D_HEIGHT / 2, "table");
     this.gameState = GameState.BETTING;
+
+    console.log("aaaaaaaaaaaaaaaa");
+    console.log(Game.CONFIG.DIFFICULTY);
+    console.log(Game.CONFIG.GAME_MODE);
 
     this.createGameZone();
     this.createDropZones();

--- a/src/scenes/games/speed/speedTableScene.ts
+++ b/src/scenes/games/speed/speedTableScene.ts
@@ -54,10 +54,6 @@ export default class SpeedTableScene extends TableScene {
     this.add.image(D_WIDTH / 2, D_HEIGHT / 2, "table");
     this.gameState = GameState.BETTING;
 
-    console.log("aaaaaaaaaaaaaaaa");
-    console.log(Game.CONFIG.DIFFICULTY);
-    console.log(Game.CONFIG.GAME_MODE);
-
     this.createGameZone();
     this.createDropZones();
     this.createCardDropEvent();

--- a/src/scenes/games/speed/speedTableScene.ts
+++ b/src/scenes/games/speed/speedTableScene.ts
@@ -495,31 +495,3 @@ export default class SpeedTableScene extends TableScene {
     });
   }
 }
-
-const config: Phaser.Types.Core.GameConfig = {
-  type: Phaser.AUTO,
-  width: D_WIDTH,
-  height: D_HEIGHT,
-  antialias: false,
-  scene: SpeedTableScene,
-  mode: Phaser.Scale.FIT,
-  parent: "game-content",
-  autoCenter: Phaser.Scale.CENTER_BOTH,
-  min: {
-    width: 720,
-    height: 345,
-  },
-  max: {
-    width: 1920,
-    height: 920,
-  },
-  fps: {
-    target: 60,
-    forceSetTimeOut: true,
-  },
-  physics: {
-    default: "arcade",
-  },
-};
-
-const phaser = new Phaser.Game(config);

--- a/src/scenes/games/war/warTableScene.ts
+++ b/src/scenes/games/war/warTableScene.ts
@@ -294,31 +294,3 @@ export default class WarTableScene extends TableScene {
     return playerScore === dealerScore && this.didWar;
   }
 }
-
-const config: Phaser.Types.Core.GameConfig = {
-  type: Phaser.AUTO,
-  width: D_WIDTH,
-  height: D_HEIGHT,
-  antialias: false,
-  scene: WarTableScene,
-  mode: Phaser.Scale.FIT,
-  parent: "game-content",
-  autoCenter: Phaser.Scale.CENTER_BOTH,
-  min: {
-    width: 720,
-    height: 345,
-  },
-  max: {
-    width: 1920,
-    height: 920,
-  },
-  fps: {
-    target: 60,
-    forceSetTimeOut: true,
-  },
-  physics: {
-    default: "arcade",
-  },
-};
-
-const phaser = new Phaser.Game(config);


### PR DESCRIPTION
## 関連するIssueやプルリクエスト
#54 

## 変更の概要
ゲーム情報を各ゲームで扱えるようにする。

## なぜこの変更をするのか
- 難易度を識別できる
- 選択されたゲームが識別できるなど


## 変更内容
- ゲーム情報を各ゲームで共有
- Phaserの設定を1つにまとめる
- レンダリングなしでゲームを開始

## どうやるのか

https://github.com/Recursion-Group-B/card-game/assets/69625901/896113e1-1149-4f94-9164-b170c35712d1


## 課題
実際に難易度情報を渡す処理はmotsuさんがhome画面のUI調整後に行います。
今回はレンダリングなしでPhaserを読み込む処理まで作ってます 
