### PR TITLE
ゲーム進行のインフォメーション実装

### DIFF
--- a/src/constants/gameState.ts
+++ b/src/constants/gameState.ts
@@ -8,6 +8,8 @@ enum GameState {
   END_GAME = "endGame",
   GAME_OVER = "gameOver",
   FIRST_CYCLE = "firstCycle",
+  SECOND_CYCLE = "secondCycle",
+  THIRD_CYCLE = "thirdCycle",
   CHANGE_CYCLE = "changeCycle",
   INIT_GAME = "initGame",
 }

--- a/src/constants/gameState.ts
+++ b/src/constants/gameState.ts
@@ -7,6 +7,9 @@ enum GameState {
   DOUBLE = "double",
   END_GAME = "endGame",
   GAME_OVER = "gameOver",
+  FIRST_CYCLE = "firstCycle",
+  CHANGE_CYCLE = "changeCycle",
+  INIT_GAME = "initGame",
 }
 
 export default GameState;

--- a/src/scenes/common/TableScene.ts
+++ b/src/scenes/common/TableScene.ts
@@ -610,7 +610,11 @@ export default abstract class TableScene extends Phaser.Scene {
       case GameState.INIT_GAME:
         this.infoContent = "画面をクリックしてベットに戻ります。";
         timeout =
-          this.gameSceneKey === GameType.POKER || this.gameSceneKey === GameType.TEXAS ? 2000 : 0;
+          this.gameSceneKey === GameType.POKER ||
+          this.gameSceneKey === GameType.TEXAS ||
+          this.gameSceneKey === GameType.BLACKJACK
+            ? 1500
+            : 0;
         break;
       case GameState.BETTING:
         this.infoContent = "ベットサイズを決めてください。";

--- a/src/scenes/common/TableScene.ts
+++ b/src/scenes/common/TableScene.ts
@@ -600,6 +600,7 @@ export default abstract class TableScene extends Phaser.Scene {
    * インフォメーションの更新
    */
   protected drawInfo(): void {
+    let timeout = 0;
     switch (this.gameState) {
       case GameState.COMPARE:
         this.infoContent = "勝敗の確認中です。";
@@ -607,6 +608,7 @@ export default abstract class TableScene extends Phaser.Scene {
       case GameState.END_GAME:
       case GameState.INIT_GAME:
         this.infoContent = "画面をクリックしてベットに戻ります。";
+        timeout = 2000;
         break;
       case GameState.BETTING:
         this.infoContent = "ベットサイズを決めてください。";
@@ -617,7 +619,9 @@ export default abstract class TableScene extends Phaser.Scene {
       default:
         this.infoContent = "プレイ中です。";
     }
-    (this.infoContainer.getByName("info_text") as Text).setText(this.infoContent);
+    setTimeout(() => {
+      (this.infoContainer.getByName("info_text") as Text).setText(this.infoContent);
+    }, timeout);
   }
 
   /**

--- a/src/scenes/common/TableScene.ts
+++ b/src/scenes/common/TableScene.ts
@@ -600,7 +600,6 @@ export default abstract class TableScene extends Phaser.Scene {
    * インフォメーションの更新
    */
   protected drawInfo(): void {
-    console.log(this.gameState);
     switch (this.gameState) {
       case GameState.COMPARE:
         this.infoContent = "勝敗の確認中です。";

--- a/src/scenes/common/TableScene.ts
+++ b/src/scenes/common/TableScene.ts
@@ -601,6 +601,7 @@ export default abstract class TableScene extends Phaser.Scene {
    */
   protected drawInfo(): void {
     let timeout = 0;
+
     switch (this.gameState) {
       case GameState.COMPARE:
         this.infoContent = "勝敗の確認中です。";
@@ -608,7 +609,8 @@ export default abstract class TableScene extends Phaser.Scene {
       case GameState.END_GAME:
       case GameState.INIT_GAME:
         this.infoContent = "画面をクリックしてベットに戻ります。";
-        timeout = 2000;
+        timeout =
+          this.gameSceneKey === GameType.POKER || this.gameSceneKey === GameType.TEXAS ? 2000 : 0;
         break;
       case GameState.BETTING:
         this.infoContent = "ベットサイズを決めてください。";
@@ -619,6 +621,7 @@ export default abstract class TableScene extends Phaser.Scene {
       default:
         this.infoContent = "プレイ中です。";
     }
+
     setTimeout(() => {
       (this.infoContainer.getByName("info_text") as Text).setText(this.infoContent);
     }, timeout);

--- a/src/scenes/common/TableScene.ts
+++ b/src/scenes/common/TableScene.ts
@@ -592,6 +592,8 @@ export default abstract class TableScene extends Phaser.Scene {
 
     this.infoContainer = this.add.container(0, 0, [infoBackGround, infoText]).setName("info");
     Phaser.Display.Align.In.TopCenter(this.infoContainer, this.gameZone as Zone, -300, -5);
+
+    this.drawInfo();
   }
 
   /**
@@ -604,6 +606,7 @@ export default abstract class TableScene extends Phaser.Scene {
         this.infoContent = "勝敗の確認中です。";
         break;
       case GameState.END_GAME:
+      case GameState.INIT_GAME:
         this.infoContent = "画面をクリックしてベットに戻ります。";
         break;
       case GameState.BETTING:

--- a/src/scenes/common/TableScene.ts
+++ b/src/scenes/common/TableScene.ts
@@ -8,6 +8,7 @@ import GameResult from "../../constants/gameResult";
 import GAME from "../../models/common/game";
 import Zone = Phaser.GameObjects.Zone;
 import Text = Phaser.GameObjects.Text;
+import Container = Phaser.GameObjects.Container;
 import GameObject = Phaser.GameObjects.GameObject;
 import HelpContainer from "./helpContainer";
 import { textStyle } from "../../constants/styles";
@@ -16,6 +17,8 @@ import Size from "../../constants/size";
 
 export default abstract class TableScene extends Phaser.Scene {
   protected gameZone: Zone | undefined;
+
+  protected infoContainer: Container | undefined;
 
   protected pot: number[];
 
@@ -76,6 +79,8 @@ export default abstract class TableScene extends Phaser.Scene {
   protected playerDrawSound: Phaser.Sound.BaseSound | undefined;
 
   protected isSoundOn = true;
+
+  protected infoContent: string | undefined;
 
   protected set setInitialTime(time: number) {
     this.initialTime = time;
@@ -562,6 +567,55 @@ export default abstract class TableScene extends Phaser.Scene {
       (child) => child.name === "pots_background" || child.name === "pots_text"
     );
     this.add.container(potsX, potsY, potsChildren).setName("pots");
+  }
+
+  /**
+   * インフォメーション
+   */
+  protected createInfo(): void {
+    // 背景
+    const infoBackGround = this.add
+      .graphics()
+      .fillRoundedRect(0, 0, 600, 40)
+      .fillStyle(0x000000, 0.9)
+      .setName("info_background");
+
+    // テキスト
+    const infoText = this.add
+      .text(0, 0, this.infoContent)
+      .setColor("white")
+      .setFontSize(20)
+      .setFontFamily("Arial")
+      .setPadding(20, 8)
+      .setOrigin(0, 0)
+      .setName("info_text");
+
+    this.infoContainer = this.add.container(0, 0, [infoBackGround, infoText]).setName("info");
+    Phaser.Display.Align.In.TopCenter(this.infoContainer, this.gameZone as Zone, -300, -5);
+  }
+
+  /**
+   * インフォメーションの更新
+   */
+  protected drawInfo(): void {
+    console.log(this.gameState);
+    switch (this.gameState) {
+      case GameState.COMPARE:
+        this.infoContent = "勝敗の確認中です。";
+        break;
+      case GameState.END_GAME:
+        this.infoContent = "画面をクリックしてベットに戻ります。";
+        break;
+      case GameState.BETTING:
+        this.infoContent = "ベットサイズを決めてください。";
+        break;
+      case GameState.SELECT_ACE_VALUE:
+        this.infoContent = "Aceの大きさを決めてください。";
+        break;
+      default:
+        this.infoContent = "プレイ中です。";
+    }
+    (this.infoContainer.getByName("info_text") as Text).setText(this.infoContent);
   }
 
   /**

--- a/src/scenes/games/blackjack/blackjackTableScene.ts
+++ b/src/scenes/games/blackjack/blackjackTableScene.ts
@@ -82,10 +82,12 @@ export default class BlackJackTableScene extends TableScene {
     this.createToggleSoundButton();
     this.createActionButton();
     this.createScore();
+    this.createInfo();
   }
 
   update(): void {
     this.drawActionButtonControl();
+    this.drawInfo();
     this.setCreditText(this.getPlayer.getChips);
 
     if (this.gameState === GameState.PLAYING && !this.gameStarted) {
@@ -112,7 +114,7 @@ export default class BlackJackTableScene extends TableScene {
       this.saveHighScore(this.getPlayer.getChips, GameType.BLACKJACK);
       this.gameStarted = false;
 
-      this.time.delayedCall(1300, () => {
+      this.time.delayedCall(2000, () => {
         // リザルト
         this.displayResult(this.result, 0);
         this.payOut();

--- a/src/scenes/games/blackjack/blackjackTableScene.ts
+++ b/src/scenes/games/blackjack/blackjackTableScene.ts
@@ -28,9 +28,9 @@ export default class BlackJackTableScene extends TableScene {
 
   private addCpuPositionX = 0;
 
-  private playerTotalhand = 0;
+  private playerTotalHand = 0;
 
-  private cpuTotalhand = 0;
+  private cpuTotalHand = 0;
 
   private playerScoreText: Phaser.GameObjects.Text;
 
@@ -114,7 +114,7 @@ export default class BlackJackTableScene extends TableScene {
       this.saveHighScore(this.getPlayer.getChips, GameType.BLACKJACK);
       this.gameStarted = false;
 
-      this.time.delayedCall(2000, () => {
+      this.time.delayedCall(1500, () => {
         // リザルト
         this.displayResult(this.result, 0);
         this.payOut();
@@ -137,8 +137,8 @@ export default class BlackJackTableScene extends TableScene {
     // 現状のデータを初期化させる
     this.addPlayerPositionX = 0;
     this.addCpuPositionX = 0;
-    this.playerTotalhand = 0;
-    this.cpuTotalhand = 0;
+    this.playerTotalHand = 0;
+    this.cpuTotalHand = 0;
     this.bet = 0;
     this.setBetText();
 
@@ -199,7 +199,7 @@ export default class BlackJackTableScene extends TableScene {
             if (card.getRank === "Ace") {
               this.createAceValueButton(card);
             } else {
-              this.playerTotalhand += card.getRankNumber(GameType.BLACKJACK);
+              this.playerTotalHand += card.getRankNumber(GameType.BLACKJACK);
             }
             this.setDisplayTotal(PlayerType.PLAYER);
             card.flipToFront();
@@ -211,7 +211,7 @@ export default class BlackJackTableScene extends TableScene {
           // ブラックジャックはCPUの一枚目を表面にする
           if (index === 0) {
             card.moveTo(this.cpuPositionX + this.addCpuPositionX, this.cpuPositionY, 500);
-            this.cpuTotalhand += card.getRankNumber(GameType.BLACKJACK);
+            this.cpuTotalHand += card.getRankNumber(GameType.BLACKJACK);
             setTimeout(() => {
               this.setDisplayTotal(PlayerType.CPU);
               card.flipToFront();
@@ -222,7 +222,7 @@ export default class BlackJackTableScene extends TableScene {
             card.moveTo(this.cpuPositionX + this.addCpuPositionX, this.cpuPositionY, 500);
             this.addCpuPositionX += 85;
             setTimeout(() => {
-              this.cpuTotalhand += card.getRankNumber(GameType.BLACKJACK);
+              this.cpuTotalHand += card.getRankNumber(GameType.BLACKJACK);
             }, 800);
           }
         }
@@ -236,7 +236,7 @@ export default class BlackJackTableScene extends TableScene {
   createScore(): void {
     // player
     this.playerScoreText = this.add
-      .text(this.playerPositionX + 120, this.playerPositionY - 95, `${this.playerTotalhand}`, {
+      .text(this.playerPositionX + 120, this.playerPositionY - 95, `${this.playerTotalHand}`, {
         fontFamily: "Arial Black",
         fontSize: 30,
       })
@@ -245,7 +245,7 @@ export default class BlackJackTableScene extends TableScene {
 
     // CPU
     this.cpuScoreText = this.add
-      .text(this.cpuPositionX + 120, this.cpuPositionY + 65, `${this.cpuTotalhand}`, {
+      .text(this.cpuPositionX + 120, this.cpuPositionY + 65, `${this.cpuTotalHand}`, {
         fontFamily: "Arial Black",
         fontSize: 30,
       })
@@ -263,14 +263,14 @@ export default class BlackJackTableScene extends TableScene {
   private setDisplayTotal(playerType?: PlayerType): void {
     switch (playerType) {
       case PlayerType.CPU:
-        this.cpuScoreText.setText(this.cpuTotalhand.toString());
+        this.cpuScoreText.setText(this.cpuTotalHand.toString());
         break;
       case PlayerType.PLAYER:
-        this.playerScoreText.setText(this.playerTotalhand.toString());
+        this.playerScoreText.setText(this.playerTotalHand.toString());
         break;
       default:
-        this.cpuScoreText.setText(this.cpuTotalhand.toString());
-        this.playerScoreText.setText(this.playerTotalhand.toString());
+        this.cpuScoreText.setText(this.cpuTotalHand.toString());
+        this.playerScoreText.setText(this.playerTotalHand.toString());
         break;
     }
   }
@@ -288,11 +288,11 @@ export default class BlackJackTableScene extends TableScene {
    */
   private compareHands = (): void => {
     if (this.result === GameResult.SURRENDER) return;
-    if (this.playerTotalhand > 21) {
+    if (this.playerTotalHand > 21) {
       this.result = GameResult.BUST;
-    } else if (this.playerTotalhand > this.cpuTotalhand || this.cpuTotalhand > 21) {
+    } else if (this.playerTotalHand > this.cpuTotalHand || this.cpuTotalHand > 21) {
       this.result = GameResult.WIN;
-    } else if (this.playerTotalhand === this.cpuTotalhand) {
+    } else if (this.playerTotalHand === this.cpuTotalHand) {
       this.result = GameResult.DRAW;
     } else {
       this.result = GameResult.LOSE;
@@ -327,7 +327,7 @@ export default class BlackJackTableScene extends TableScene {
     });
 
     // ② 17以上になるまでHitを行う
-    while (this.cpuTotalhand < 17) {
+    while (this.cpuTotalHand < 17) {
       // カードを一枚ドロー
       this.drawCard(PlayerType.CPU);
     }
@@ -372,7 +372,7 @@ export default class BlackJackTableScene extends TableScene {
     // 次のカードに渡す情報 / 現在のトータルスコアを更新
     if (playerType === PlayerType.CPU) {
       this.addCpuPositionX += 85;
-      this.cpuTotalhand += drawCard.getRankNumber(GameType.BLACKJACK);
+      this.cpuTotalHand += drawCard.getRankNumber(GameType.BLACKJACK);
     } else if (playerType === PlayerType.PLAYER && drawCard.getRank === "Ace") {
       this.addPlayerPositionX += 85;
       setTimeout(() => {
@@ -380,11 +380,11 @@ export default class BlackJackTableScene extends TableScene {
       }, 600);
     } else if (this.gameState === GameState.HIT || this.gameState === GameState.PLAYING) {
       this.addPlayerPositionX += 85;
-      this.playerTotalhand += drawCard.getRankNumber(GameType.BLACKJACK);
+      this.playerTotalHand += drawCard.getRankNumber(GameType.BLACKJACK);
       this.gameState = GameState.HIT;
     } else if (this.gameState === GameState.DOUBLE) {
       this.addPlayerPositionX += 85;
-      this.playerTotalhand += drawCard.getRankNumber(GameType.BLACKJACK);
+      this.playerTotalHand += drawCard.getRankNumber(GameType.BLACKJACK);
       this.gameState = GameState.COMPARE;
     }
 
@@ -437,7 +437,7 @@ export default class BlackJackTableScene extends TableScene {
       this.setDisplayTotal(PlayerType.PLAYER);
       this.gameState = GameState.HIT;
 
-      if (this.playerTotalhand > 21) this.gameState = GameState.COMPARE;
+      if (this.playerTotalHand > 21) this.gameState = GameState.COMPARE;
     });
   }
 
@@ -560,12 +560,12 @@ export default class BlackJackTableScene extends TableScene {
     this.aceCards.unshift(aceCard);
 
     const clickAction = (type: GameType) => () => {
-      this.playerTotalhand += aceCard.getRankNumber(type);
+      this.playerTotalHand += aceCard.getRankNumber(type);
       aceCard.moveTo(aceCard.getX, aceCard.getY + 10, 100);
       aceCard.preFX.clear();
       this.setDisplayTotal(PlayerType.PLAYER);
       this.removeAceValueButton(aceCard);
-      if (this.playerTotalhand > 21) this.gameState = GameState.COMPARE;
+      if (this.playerTotalHand > 21) this.gameState = GameState.COMPARE;
       else if (!this.aceCards.length)
         this.gameState = preGameState === GameState.DOUBLE ? GameState.COMPARE : GameState.HIT;
     };

--- a/src/scenes/games/poker/pokerTableScene.ts
+++ b/src/scenes/games/poker/pokerTableScene.ts
@@ -135,9 +135,10 @@ export default class PokerTableScene extends TableScene {
     // gameState管理
     this.cycleControl();
 
-    // 所持金等の更新
+    // 更新
     this.setBetText(GameType.POKER);
     this.setCreditText(this.getPlayer.getChips);
+    this.drawInfo();
   }
 
   private async cycleEvent(player: PokerPlayer, index: number): Promise<void> {
@@ -172,7 +173,6 @@ export default class PokerTableScene extends TableScene {
       this.gameStarted = true;
       this.startGame();
       this.disableBetItem();
-      this.drawInfo();
     }
     // レイズした場合、もう一周
     if (this.players.some((player: PokerPlayer) => player.getState === "raise")) {
@@ -246,7 +246,6 @@ export default class PokerTableScene extends TableScene {
       this.gameState = GameState.INIT_GAME;
 
       this.time.delayedCall(2000, () => {
-        this.drawInfo();
         this.displayResult(this.result as string, 0);
         this.resultView();
         this.saveHighScore(this.getPlayer.getChips, GameType.POKER);
@@ -706,7 +705,6 @@ export default class PokerTableScene extends TableScene {
     this.dealButton?.disVisibleText();
     this.enableBetItem();
     this.fadeInBetItem();
-    this.drawInfo();
   }
 
   private startGame(): void {

--- a/src/scenes/games/poker/pokerTableScene.ts
+++ b/src/scenes/games/poker/pokerTableScene.ts
@@ -59,6 +59,7 @@ export default class PokerTableScene extends TableScene {
     ];
     this.pot = [0];
     this.returnPot = 0;
+    this.gameState = GameState.BETTING;
     this.cycleState = "notAllAction";
     this.gameStarted = false;
   }
@@ -121,6 +122,7 @@ export default class PokerTableScene extends TableScene {
     this.createDealButton(true);
     this.createCreditField(GameType.POKER);
     this.drawAction();
+    this.createInfo();
 
     // アニメーション
     this.clickToUp();
@@ -131,6 +133,7 @@ export default class PokerTableScene extends TableScene {
   update(): void {
     // gameState管理
     this.cycleControl();
+    this.drawInfo();
 
     // 所持金等の更新
     this.setBetText(GameType.POKER);
@@ -152,7 +155,7 @@ export default class PokerTableScene extends TableScene {
     if (player.getState !== "notAction") return;
 
     // ゲーム終了時は何もしない
-    if (this.gameState === "endGame" || this.gameState === "compare") return;
+    if (this.gameState === GameState.END_GAME || this.gameState === GameState.COMPARE) return;
 
     // cpu
     if (player.getPlayerType === "cpu") {

--- a/src/scenes/games/poker/pokerTableScene.ts
+++ b/src/scenes/games/poker/pokerTableScene.ts
@@ -385,20 +385,20 @@ export default class PokerTableScene extends TableScene {
     );
     this.changeBtn.disable();
     this.changeBtn.setClickHandler(() => {
-      this.players.forEach((player) => {
+      this.players.forEach((player: PokerPlayer) => {
         if (player.getPlayerType !== "player") return;
         // data
-        const changeList = (player.getHand as Card[]).filter(
-          (child) => (child as Card).getClickStatus === true
+        const changeList = player.getHand.filter(
+          (child: Card) => child.getClickStatus === true
         ) as Card[];
-        if (changeList.length)
+        if (changeList.length) {
           (player as PokerPlayer).change(
             changeList,
             (this.deck as Deck).draw(changeList.length) as Card[]
           );
-        // phaser描画
-        changeList.forEach((card) => card.destroy());
-        this.dealHand();
+          changeList.forEach((card) => card.destroy());
+          this.dealHand();
+        }
         // state更新
         (player as PokerPlayer).setState = "Done";
         // action表示

--- a/src/scenes/games/poker/pokerTableScene.ts
+++ b/src/scenes/games/poker/pokerTableScene.ts
@@ -234,29 +234,31 @@ export default class PokerTableScene extends TableScene {
 
     // 手札を比較し、ゲーム終了
     if (this.gameState === GameState.COMPARE) {
-      this.gameState = GameState.END_GAME;
       this.deleteDoneAction();
       this.disableBtn();
-      this.checkResult();
+      this.time.delayedCall(500, () => {
+        this.checkResult();
+        this.gameState = GameState.END_GAME;
+      });
     }
 
     // リザルト表示し、リスタート
-    if (this.gameState === GameState.END_GAME) {
+    if (this.gameState === GameState.END_GAME && this.gameStarted) {
       this.time.removeAllEvents();
-      this.gameState = GameState.INIT_GAME;
+      this.gameStarted = false;
 
-      this.time.delayedCall(2000, () => {
+      this.time.delayedCall(1500, () => {
         this.displayResult(this.result as string, 0);
         this.resultView();
         this.saveHighScore(this.getPlayer.getChips, GameType.POKER);
-      });
 
-      // リスタート
-      this.gameZone.setInteractive();
-      this.gameZone.on("pointerdown", () => {
-        this.initGame();
-        this.gameZone.removeInteractive();
-        this.gameZone.removeAllListeners();
+        // リスタート
+        this.gameZone.setInteractive();
+        this.gameZone.on("pointerdown", () => {
+          this.initGame();
+          this.gameZone.removeInteractive();
+          this.gameZone.removeAllListeners();
+        });
       });
     }
   }

--- a/src/scenes/games/poker/pokerTableScene.ts
+++ b/src/scenes/games/poker/pokerTableScene.ts
@@ -1,5 +1,5 @@
 import "../../../style.scss";
-import Phaser, { Game } from "phaser";
+import Phaser from "phaser";
 import Deck from "../../../models/common/deck";
 import Card from "../../../models/common/card";
 import Button from "../../../models/common/button";
@@ -565,7 +565,6 @@ export default class PokerTableScene extends TableScene {
 
     this.players.forEach((player: PokerPlayer) => {
       const handScore: HandScore = player.calculateHandScore();
-      console.log(`${player.getName} role: ${handScore.role}`);
       this.handScoreList.push(handScore);
       scoreList.add(handScore.role);
     });

--- a/src/scenes/games/poker/pokerTableScene.ts
+++ b/src/scenes/games/poker/pokerTableScene.ts
@@ -160,7 +160,7 @@ export default class PokerTableScene extends TableScene {
 
     // cpu
     if (player.getPlayerType === "cpu") {
-      await this.cpuAction(player);
+      await this.cpuAction(player, index);
     }
   }
 
@@ -263,7 +263,7 @@ export default class PokerTableScene extends TableScene {
     }
   }
 
-  private cpuAction(player: PokerPlayer): Promise<PokerPlayer> {
+  private cpuAction(player: PokerPlayer, index: number): Promise<PokerPlayer> {
     return new Promise(() => {
       setTimeout(() => {
         if (player.getIsDealer && this.cycleState === "notAllAction") {
@@ -288,7 +288,7 @@ export default class PokerTableScene extends TableScene {
             player.change([...changeList], this.deck?.draw(changeList.size) as Card[]);
             // phaser描画
             changeList.forEach((card) => card.destroy());
-            this.dealHand();
+            this.dealHand(index);
           }
           // state更新
           player.setState = "Done";
@@ -320,7 +320,9 @@ export default class PokerTableScene extends TableScene {
   /**
    * 手札配布
    */
-  private dealHand() {
+  private dealHand(): void;
+  private dealHand(playerIndex: number): void;
+  private dealHand(playerIndex?: number) {
     const flipTime = 800;
     let cpuTime;
     switch (this.gameState) {
@@ -331,7 +333,7 @@ export default class PokerTableScene extends TableScene {
         cpuTime = 0;
     }
 
-    this.players.forEach((player: PokerPlayer) => {
+    const deal = (player: PokerPlayer) => {
       player.getHand?.forEach((card, index) => {
         this.children.bringToTop(card);
         if (player.getPlayerType === "player") {
@@ -345,7 +347,10 @@ export default class PokerTableScene extends TableScene {
           }, cpuTime);
         }
       });
-    });
+    };
+
+    if (playerIndex === undefined) this.players.forEach((player: PokerPlayer) => deal(player));
+    else deal(this.players[playerIndex] as PokerPlayer);
   }
 
   /**
@@ -385,7 +390,7 @@ export default class PokerTableScene extends TableScene {
     );
     this.changeBtn.disable();
     this.changeBtn.setClickHandler(() => {
-      this.players.forEach((player: PokerPlayer) => {
+      this.players.forEach((player: PokerPlayer, index: number) => {
         if (player.getPlayerType !== "player") return;
         // data
         const changeList = player.getHand.filter(
@@ -397,7 +402,7 @@ export default class PokerTableScene extends TableScene {
             (this.deck as Deck).draw(changeList.length) as Card[]
           );
           changeList.forEach((card) => card.destroy());
-          this.dealHand();
+          this.dealHand(index);
         }
         // state更新
         (player as PokerPlayer).setState = "Done";

--- a/src/scenes/games/speed/speedTableScene.ts
+++ b/src/scenes/games/speed/speedTableScene.ts
@@ -67,9 +67,12 @@ export default class SpeedTableScene extends TableScene {
     this.createTutorialButton();
     this.helpContent = new HelpContainer(this, GameRule.SPEED);
     this.createHelpButton(this.helpContent);
+    this.createInfo();
   }
 
   update(): void {
+    this.drawInfo();
+
     if (this.gameState === GameState.PLAYING && !this.gameStarted) {
       this.disableBetItem();
       this.startGame();

--- a/src/scenes/games/texasholdem/texasTableScene.ts
+++ b/src/scenes/games/texasholdem/texasTableScene.ts
@@ -192,16 +192,18 @@ export default class TexasTableScene extends TableScene {
 
     // 手札を比較し、ゲーム終了
     if (this.gameState === GameState.COMPARE) {
-      this.gameState = GameState.END_GAME;
       this.disableAction();
-      this.checkResult();
+      this.time.delayedCall(500, () => {
+        this.checkResult();
+        this.gameState = GameState.END_GAME;
+      });
     }
 
     // リザルト表示し、リスタート
     if (this.gameState === GameState.END_GAME) {
       this.time.removeAllEvents();
 
-      this.time.delayedCall(2000, () => {
+      this.time.delayedCall(1500, () => {
         this.displayResult(this.result as string, 0);
         this.resultView();
         this.saveHighScore(this.getPlayer.getChips, GameType.TEXAS);
@@ -519,6 +521,7 @@ export default class TexasTableScene extends TableScene {
       scoreList.add(handScore.role);
     });
 
+    console.log(this.handScoreList);
     // 同等の役の場合、カードの強い順番
     if (scoreList.size === 1) {
       for (let i = 0; i < this.handScoreList[0].highCard.length; i += 1) {

--- a/src/scenes/games/texasholdem/texasTableScene.ts
+++ b/src/scenes/games/texasholdem/texasTableScene.ts
@@ -521,7 +521,6 @@ export default class TexasTableScene extends TableScene {
       scoreList.add(handScore.role);
     });
 
-    console.log(this.handScoreList);
     // 同等の役の場合、カードの強い順番
     if (scoreList.size === 1) {
       for (let i = 0; i < this.handScoreList[0].highCard.length; i += 1) {

--- a/src/scenes/games/war/warTableScene.ts
+++ b/src/scenes/games/war/warTableScene.ts
@@ -49,9 +49,12 @@ export default class WarTableScene extends TableScene {
     this.createHelpButton(this.helpContent);
     this.createCommonSound();
     this.createToggleSoundButton();
+    this.createInfo();
   }
 
   update(): void {
+    this.drawInfo();
+
     if (this.gameState === GameState.PLAYING && !this.gameStarted) {
       this.disableBetItem();
       this.startGame();


### PR DESCRIPTION
## 関連するIssueやプルリクエスト
#82

## 変更の概要
ユーザー操作案内のインフォメーション作成

## なぜこの変更をするのか
ゲーム終了時にクリックしてbettingへ移行するが、案内がないため最初はわからないから。
ついでに、GameStateにてそれぞれの状態をインフォメーションにて案内している。


## 変更内容

[screen-recording (7).webm](https://github.com/Recursion-Group-B/card-game/assets/80054036/0a203c3e-d673-4c18-a30f-044d3db4d5df)


## どうやるのか
create()へcreateInfo()を追加
update()へdrawInfoを追加
各ゲームに反映済み。

## 備考
他に何か案内が必要あればコメントお願いします。