### PR TITLE
ベットできない場合、ベットボタンを非表示

### DIFF
--- a/src/scenes/games/poker/pokerTableScene.ts
+++ b/src/scenes/games/poker/pokerTableScene.ts
@@ -792,5 +792,9 @@ export default class PokerTableScene extends TableScene {
       this.raiseBtn?.disable();
       this.changeBtn?.enable();
     }
+
+    if (this.bet > this.getPlayer.getChips) {
+      this.betBtn.disable();
+    }
   }
 }

--- a/src/scenes/games/poker/pokerTableScene.ts
+++ b/src/scenes/games/poker/pokerTableScene.ts
@@ -794,6 +794,8 @@ export default class PokerTableScene extends TableScene {
     }
 
     if (this.bet > this.getPlayer.getChips) {
+      this.callBtn.disable();
+      this.raiseBtn.disable();
       this.betBtn.disable();
     }
   }

--- a/src/scenes/games/texasholdem/texasTableScene.ts
+++ b/src/scenes/games/texasholdem/texasTableScene.ts
@@ -775,6 +775,8 @@ export default class TexasTableScene extends TableScene {
     }
 
     if (this.bet > this.getPlayer.getChips) {
+      this.callBtn.disable();
+      this.raiseBtn.disable();
       this.betBtn.disable();
     }
   }

--- a/src/scenes/games/texasholdem/texasTableScene.ts
+++ b/src/scenes/games/texasholdem/texasTableScene.ts
@@ -773,5 +773,9 @@ export default class TexasTableScene extends TableScene {
       this.callBtn?.enable();
       this.raiseBtn?.enable();
     }
+
+    if (this.bet > this.getPlayer.getChips) {
+      this.betBtn.disable();
+    }
   }
 }


### PR DESCRIPTION
## 関連するIssueやプルリクエスト
#82

## 変更の概要
ベットできない場合の、別途ボタン非表示
